### PR TITLE
Handle Current JSON Payloads and Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Install or upgrade pylistenbrainz with:
 
 ## Support
 
-You can ask questions about how to use pylistenbrainz on IRC (freenode #metabrainz).
+You can ask questions about how to use pylistenbrainz on IRC (Libera.Chat #metabrainz).
 You can also email me at `iliekcomputers [at] gmail [dot] com`.
 
 If you have found a bug or have a feature request, let me know by opening an issue (or a pull request).

--- a/pylistenbrainz/listen.py
+++ b/pylistenbrainz/listen.py
@@ -42,6 +42,7 @@ class Listen:
         listening_from=None,
         isrc=None,
         additional_info=None,
+        mbid_mapping=None,
         username=None
     ):
         """ Creates a Listen.
@@ -101,6 +102,7 @@ class Listen:
         self.listening_from = listening_from
         self.isrc = isrc
         self.additional_info = additional_info or {}
+        self.mbid_mapping = mbid_mapping or {}
         self.username = username
 
 
@@ -109,10 +111,6 @@ class Listen:
         additional_info = self.additional_info
         if self.recording_mbid:
             additional_info['recording_mbid'] = self.recording_mbid
-        if self.artist_mbids:
-            additional_info['artist_mbids'] = self.artist_mbids
-        if self.release_mbid:
-            additional_info['release_mbid'] = self.release_mbid
         if self.tags:
             additional_info['tags'] = self.tags
         if self.release_group_mbid:
@@ -127,6 +125,13 @@ class Listen:
             additional_info['listening_from'] = self.listening_from
         if self.isrc:
             additional_info['isrc'] = self.isrc
+
+        # create the mbid_mapping dict first
+        mbid_mapping = self.mbid_mapping
+        if self.artist_mbids:
+            mbid_mapping['artist_mbids'] = self.artist_mbids
+        if self.release_mbid:
+            mbid_mapping['release_mbid'] = self.release_mbid
 
         # create track_metadata now and put additional_info into it if it makes sense
         track_metadata = {

--- a/pylistenbrainz/utils.py
+++ b/pylistenbrainz/utils.py
@@ -36,14 +36,15 @@ def _validate_submit_listens_payload(listen_type, listens):
 def _convert_api_payload_to_listen(data):
     track_metadata = data['track_metadata']
     additional_info = track_metadata.get('additional_info', {})
+    mbid_mapping = track_metadata.get('mbid_mapping', {})
     return Listen(
         track_name=track_metadata['track_name'],
         artist_name=track_metadata['artist_name'],
         listened_at=data.get('listened_at'),
         release_name=track_metadata.get('release_name'),
         recording_mbid=additional_info.get('recording_mbid'),
-        artist_mbids=additional_info.get('artist_mbids', []),
-        release_mbid=additional_info.get('release_mbid'),
+        artist_mbids=mbid_mapping.get('artist_mbids', []),
+        release_mbid=mbid_mapping.get('release_mbid'),
         tags=additional_info.get('tags', []),
         release_group_mbid=additional_info.get('release_group_mbid'),
         work_mbids=additional_info.get('work_mbids', []),
@@ -52,5 +53,6 @@ def _convert_api_payload_to_listen(data):
         listening_from=additional_info.get('listening_from'),
         isrc=additional_info.get('isrc'),
         additional_info=additional_info,
+        mbid_mapping=mbid_mapping,
         username=data.get('username'),
     )


### PR DESCRIPTION
Not sure if/when listenbrainz API docs will be updated, but this doesn't conform with the JSON they describe. This change does work with the JSON that's being returned from the API.

Docs for reference: https://listenbrainz.readthedocs.io/en/latest/users/json.html

Also update IRC network in support section of the README.